### PR TITLE
Added option to extract mesh from a trained model with --mesh_only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ configargparse
 tensorboard==1.14.0
 tqdm
 opencv-python
+trimesh
+pymcubes


### PR DESCRIPTION
Added code adapted from the [original tensorflow implementation](https://github.com/bmild/nerf/blob/master/extract_mesh.ipynb) to extract a mesh from the network and save it to a .obj file. This can be activated with `--mesh_only`, which loads trained weights and extracts a mesh by querying the network function and running marching cubes. Added two dependencies (trimesh and pymcubes). 