### PR TITLE
Remove torchsearchsorted dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.4.0
+torch>=1.7.0
 torchvision>=0.2.1
 imageio
 imageio-ffmpeg

--- a/run_nerf_helpers.py
+++ b/run_nerf_helpers.py
@@ -4,9 +4,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
 
-# TODO: remove this dependency
-from torchsearchsorted import searchsorted
-
 
 # Misc
 img2mse = lambda x, y : torch.mean((x - y) ** 2)
@@ -223,7 +220,7 @@ def sample_pdf(bins, weights, N_samples, det=False, pytest=False):
 
     # Invert CDF
     u = u.contiguous()
-    inds = searchsorted(cdf, u, side='right')
+    inds = torch.searchsorted(cdf, u, right=True)
     below = torch.max(torch.zeros_like(inds-1), inds-1)
     above = torch.min((cdf.shape[-1]-1) * torch.ones_like(inds), inds)
     inds_g = torch.stack([below, above], -1)  # (batch, N_samples, 2)


### PR DESCRIPTION
The `torchsearchsorted` repo is deprecated. I removed this in favor of [pytorch's implementation of `searchsorted`](https://pytorch.org/docs/stable/generated/torch.searchsorted.html).