### PR TITLE
fix the bug about the image dimension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.dae
 data/*
 logs/*
+.vscode/

--- a/load_blender.py
+++ b/load_blender.py
@@ -81,7 +81,11 @@ def load_blender_data(basedir, half_res=False, testskip=1):
 
         imgs_half_res = np.zeros((imgs.shape[0], H, W, 4))
         for i, img in enumerate(imgs):
-            imgs_half_res[i] = cv2.resize(img, (H, W), interpolation=cv2.INTER_AREA)
+            # According to the api defined in the link below, the dimension 
+            # should be represented as (W, H).
+            # https://www.tutorialkart.com/opencv/python/opencv-python-resize-image/
+            imgs_half_res[i] = cv2.resize(img, (W, H), interpolation=cv2.INTER_AREA)
+            # imgs_half_res[i] = cv2.resize(img, (H, W), interpolation=cv2.INTER_AREA)
         imgs = imgs_half_res
         # imgs = tf.image.resize_area(imgs, [400, 400]).numpy()
 


### PR DESCRIPTION
In the `load_blender.py`,  the target image dimension in `cv2.resize` should be represented as (W, H).
Here is the reference for `cv2.resize`.
https://www.tutorialkart.com/opencv/python/opencv-python-resize-image/ 

This bug is relatively minor since the images from the official NeRF paper are all square. However, if we use the data collected on our own, it will cause a **size mismatch** error.