### PR TITLE
Replicate initialization from tensorflow

### DIFF
--- a/run_nerf_helpers.py
+++ b/run_nerf_helpers.py
@@ -13,6 +13,15 @@ img2mse = lambda x, y : torch.mean((x - y) ** 2)
 mse2psnr = lambda x : -10. * torch.log(x) / torch.log(torch.Tensor([10.]))
 to8b = lambda x : (255*np.clip(x,0,1)).astype(np.uint8)
 
+class DenseLayer(nn.Linear):
+    def __init__(self, in_dim: int, out_dim: int, activation: str = "relu", *args, **kwargs) -> None:
+        self.activation = activation
+        super().__init__(in_dim, out_dim, *args, **kwargs)
+
+    def reset_parameters(self) -> None:
+        torch.nn.init.xavier_uniform_(self.weight, gain=torch.nn.init.calculate_gain(self.activation))
+        if self.bias is not None:
+            torch.nn.init.zeros_(self.bias)
 
 # Positional encoding (section 5.1)
 class Embedder:
@@ -80,21 +89,21 @@ class NeRF(nn.Module):
         self.use_viewdirs = use_viewdirs
         
         self.pts_linears = nn.ModuleList(
-            [nn.Linear(input_ch, W)] + [nn.Linear(W, W) if i not in self.skips else nn.Linear(W + input_ch, W) for i in range(D-1)])
+            [DenseLayer(input_ch, W, activation="relu")] + [DenseLayer(W, W, activation="relu") if i not in self.skips else DenseLayer(W + input_ch, W, activation="relu") for i in range(D-1)])
         
         ### Implementation according to the official code release (https://github.com/bmild/nerf/blob/master/run_nerf_helpers.py#L104-L105)
-        self.views_linears = nn.ModuleList([nn.Linear(input_ch_views + W, W//2)])
+        self.views_linears = nn.ModuleList([DenseLayer(input_ch_views + W, W//2, activation="relu")])
 
         ### Implementation according to the paper
         # self.views_linears = nn.ModuleList(
         #     [nn.Linear(input_ch_views + W, W//2)] + [nn.Linear(W//2, W//2) for i in range(D//2)])
         
         if use_viewdirs:
-            self.feature_linear = nn.Linear(W, W)
-            self.alpha_linear = nn.Linear(W, 1)
-            self.rgb_linear = nn.Linear(W//2, 3)
+            self.feature_linear = DenseLayer(W, W, activation="linear")
+            self.alpha_linear = DenseLayer(W, 1, activation="linear")
+            self.rgb_linear = DenseLayer(W//2, 3, activation="linear")
         else:
-            self.output_linear = nn.Linear(W, output_ch)
+            self.output_linear = DenseLayer(W, output_ch, activation="linear")
 
     def forward(self, x):
         input_pts, input_views = torch.split(x, [self.input_ch, self.input_ch_views], dim=-1)


### PR DESCRIPTION
There are some minor inconsistencies in network initialization with respect to the TensorFlow implementation.  In particular, tf.keras.layers.Dense will use a Glorat (Xavier in PyTorch) uniform initialization scaled based on the linear layer's non-linearity and will zero out the bias.  However, torch.nn.Linear will always use Kaiming (He in TensorFlow) uniform initialization scaled with the assumption that a leaky ReLU non-linearity with negative slope = sqrt(5) will be used.  It also uses a uniform bias initialization.

The impact of using the wrong initialization is that activations throughout the network will significantly change in magnitude. 
 This is exacerbated if the depth of the network is increased resulting in vanishing gradients.  Switching the weight initialization to at least match the correct non-linearity being used will result in consistent activation magnitude throughout the network.

I ran experiments using the blender lego scene to verify that the change didn't significantly degrade previously established quality.  On average, the test set before the change had a PSNR of 31.47 and after had a PSNR of 31.52.

https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dense
```
tf.keras.layers.Dense(
    units, activation=None, use_bias=True,
    kernel_initializer='glorot_uniform',
    bias_initializer='zeros', kernel_regularizer=None,
    bias_regularizer=None, activity_regularizer=None, kernel_constraint=None,
    bias_constraint=None, **kwargs
)
```

https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/linear.py#L86-L91
```
    def reset_parameters(self) -> None:
        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
        if self.bias is not None:
            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
            bound = 1 / math.sqrt(fan_in)
            init.uniform_(self.bias, -bound, bound)
```