### PR TITLE
Add extract_mesh.ipynb

### DIFF
--- a/extract_mesh.ipynb
+++ b/extract_mesh.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import torch\n",
+    "\n",
+    "import numpy as np\n",
+    "import imageio\n",
+    "import pprint\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import run_nerf\n",
+    "import load_blender\n",
+    "\n",
+    "# General setup for GPU device and default tensor type.\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "torch.set_default_tensor_type('torch.cuda.FloatTensor')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load trained network weights\n",
+    "Note: this ipynb assumes a blender_paper_lego NeRF model is trained beforehand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "basedir = './logs'\n",
+    "expname = 'blender_paper_lego'\n",
+    "\n",
+    "config = os.path.join(basedir, expname, 'config.txt')\n",
+    "print('Args:')\n",
+    "print(open(config, 'r').read())\n",
+    "\n",
+    "parser = run_nerf.config_parser()\n",
+    "\n",
+    "args = parser.parse_args('--config {}'.format(config))\n",
+    "args.n_gpus = torch.cuda.device_count()\n",
+    "\n",
+    "# Create nerf model\n",
+    "_, render_kwargs_test, _, _, _ = run_nerf.create_nerf(args)\n",
+    "\n",
+    "bds_dict = {\n",
+    "    'near' : 2.0,\n",
+    "    'far' : 6.0,\n",
+    "}\n",
+    "render_kwargs_test.update(bds_dict)\n",
+    "\n",
+    "print('Render kwargs:')\n",
+    "pprint.pprint(render_kwargs_test)\n",
+    "\n",
+    "net_fn = render_kwargs_test['network_query_fn']\n",
+    "print(net_fn)\n",
+    "\n",
+    "# Render an overhead view to check model was loaded correctly\n",
+    "c2w = load_blender.pose_spherical(0., -90., 4.)\n",
+    "H, W, focal = 800, 800, 1200.\n",
+    "down = 8\n",
+    "with torch.no_grad():\n",
+    "    rgb, disp, _, _ = run_nerf.render(H//down, W//down, focal/down, c2w=c2w[:3, :4], **render_kwargs_test)\n",
+    "    plt.imshow(rgb.cpu())\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query network on dense 3d grid of points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N = 256\n",
+    "t = np.linspace(-1.2, 1.2, N+1)\n",
+    "\n",
+    "query_pts = np.stack(np.meshgrid(t, t, t), -1).astype(np.float32)\n",
+    "print(query_pts.shape)\n",
+    "sh = query_pts.shape\n",
+    "flat = torch.from_numpy(query_pts.reshape([-1,3]))\n",
+    "\n",
+    "\n",
+    "with torch.no_grad():\n",
+    "    fn = lambda i0, i1 : net_fn(flat[i0:i1,None,:].to(device), viewdirs=torch.zeros_like(flat[i0:i1]).to(device), network_fn=render_kwargs_test['network_fine'])\n",
+    "    chunk = 1024*64\n",
+    "    raw = np.concatenate([fn(i, i+chunk).cpu().numpy() for i in range(0, flat.shape[0], chunk)], 0)\n",
+    "    raw = np.reshape(raw, list(sh[:-1]) + [-1])\n",
+    "    sigma = np.maximum(raw[...,-1], 0.)\n",
+    "    \n",
+    "    print(raw.shape)\n",
+    "    plt.hist(np.maximum(0,sigma.ravel()), log=True)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Marching cubes with [PyMCubes](https://github.com/pmneila/PyMCubes)\n",
+    "Change `threshold` to use a different sigma threshold for the isosurface"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mcubes\n",
+    "\n",
+    "threshold = 50.\n",
+    "print('fraction occupied', np.mean(sigma > threshold))\n",
+    "vertices, triangles = mcubes.marching_cubes(sigma, threshold)\n",
+    "print('done', vertices.shape, triangles.shape)\n",
+    "\n",
+    "### Uncomment to save out the mesh\n",
+    "# mcubes.export_mesh(vertices, triangles, \"logs/lego_example/lego_{}.dae\".format(N), \"lego\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Live preview with [trimesh](https://github.com/mikedh/trimesh)\n",
+    "Click and drag to change viewpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import trimesh\n",
+    "\n",
+    "mesh = trimesh.Trimesh(vertices / N - .5, triangles)\n",
+    "mesh.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save out video with [pyrender](https://github.com/mmatl/pyrender)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['PYOPENGL_PLATFORM'] = 'egl'\n",
+    "import pyrender\n",
+    "from load_blender import pose_spherical"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scene = pyrender.Scene()\n",
+    "scene.add(pyrender.Mesh.from_trimesh(mesh, smooth=False))\n",
+    "\n",
+    "# Set up the camera -- z-axis away from the scene, x-axis right, y-axis up\n",
+    "camera = pyrender.PerspectiveCamera(yfov=np.pi / 3.0)\n",
+    "\n",
+    "camera_pose = load_blender.pose_spherical(-20., -40., 1.).cpu().numpy()\n",
+    "nc = pyrender.Node(camera=camera, matrix=camera_pose)\n",
+    "scene.add_node(nc)\n",
+    "\n",
+    "# Set up the light -- a point light in the same spot as the camera\n",
+    "light = pyrender.PointLight(color=np.ones(3), intensity=4.0)\n",
+    "nl = pyrender.Node(light=light, matrix=camera_pose)\n",
+    "scene.add_node(nl)\n",
+    "\n",
+    "# Render the scene\n",
+    "r = pyrender.OffscreenRenderer(640, 480)\n",
+    "color, depth = r.render(scene)\n",
+    "\n",
+    "plt.imshow(color)\n",
+    "plt.show()\n",
+    "plt.imshow(depth)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imgs = []\n",
+    "for th in np.linspace(0, 360., 120+1)[:-1]:\n",
+    "    camera_pose = pose_spherical(th, -40., 1.).cpu().numpy()\n",
+    "    scene.set_pose(nc, pose=camera_pose)\n",
+    "    imgs.append(r.render(scene)[0])\n",
+    "f = 'logs/blender_paper_lego/lego_mesh_turntable.mp4'\n",
+    "imageio.mimwrite(f, imgs, fps=30)\n",
+    "print('done')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import HTML\n",
+    "from base64 import b64encode\n",
+    "mp4 = open(f,'rb').read()\n",
+    "data_url = \"data:video/mp4;base64,\" + b64encode(mp4).decode()\n",
+    "HTML(\"\"\"\n",
+    "<video width=400 controls autoplay loop>\n",
+    "      <source src=\"%s\" type=\"video/mp4\">\n",
+    "</video>\n",
+    "\"\"\" % data_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Hi,

First of all, thank you for the great work porting NeRF to pytorch!

It's super easy to train models using this repository. However, I did struggle to visualize meshes given a trained result. Thus, I looked into the [extract_mesh.ipynb](https://github.com/bmild/nerf/blob/master/extract_mesh.ipynb) of the original NeRF implementation and make it compatible with this repo. Hope some other people will find that useful.

The added `extract_mesh.ipynb` is mostly a mirrored version of the original script, I just tweaked some torch or `nerf-pytorch` specific things to make it run smoothly.

Let me know if the PR looks good to you. Happy to address any comments.