### PR TITLE
Update tensorboard to 1.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ imageio
 imageio-ffmpeg
 matplotlib
 configargparse
-tensorboard==1.14.0
+tensorboard==1.15.0
 tqdm
 opencv-python


### PR DESCRIPTION
Hi, run_nerf.py throws this error for me:
ImportError: TensorBoard logging requires TensorBoard version 1.15 or above