### PR TITLE
fix urls in download_example_data.sh

### DIFF
--- a/download_example_data.sh
+++ b/download_example_data.sh
@@ -1,6 +1,6 @@
-wget https://people.eecs.berkeley.edu/~bmild/nerf/tiny_nerf_data.npz
+wget http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/tiny_nerf_data.npz
 mkdir -p data
 cd data
-wget https://people.eecs.berkeley.edu/~bmild/nerf/nerf_example_data.zip
+wget http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/nerf_example_data.zip
 unzip nerf_example_data.zip
 cd ..


### PR DESCRIPTION
Tried to recreate the steps in the readme but the bash-script for fetching data failed to pull `nerd_example_data.zip`. I looked the original nerf repo,
https://github.com/bmild/nerf/
, and copied the URLs from there which work. Looks like they had a change of paths in their repo in January. 