### PR TITLE
Add W&B Logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ configargparse
 tensorboard>=2.0
 tqdm
 opencv-python
+wandb


### PR DESCRIPTION
This PR aims to add basic [**Weights and Biases**](https://wandb.ai/site) Metric Logging by appending to the existing training scripts with minimal changes. 

The PR adds 3 extra arguments namely `--use_wandb`, `--wandb_project` and `--wandb_entity` which can be used to specify whether to use wandb, the name of the project to be used (`"nerf-pytorch"` by default) and name of the entity to be used.