### PR TITLE
Update download_example_data.sh

### DIFF
--- a/download_example_data.sh
+++ b/download_example_data.sh
@@ -1,6 +1,6 @@
-wget http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/tiny_nerf_data.npz
+wget --no-check-certificate http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/tiny_nerf_data.npz
 mkdir -p data
 cd data
-wget http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/nerf_example_data.zip
+wget --no-check-certificate http://cseweb.ucsd.edu/~viscomp/projects/LF/papers/ECCV20/nerf/nerf_example_data.zip
 unzip nerf_example_data.zip
 cd ..


### PR DESCRIPTION
For the error message indicates that wget is unable to verify the SSL certificate of the cseweb.ucsd.edu website, which is causing the download to fail. This is because the certificate is issued by InCommon RSA Server CA 2, which is not a trusted certificate authority by default.