### PR TITLE
Fix `imread` call to use `apply_gamma` instead of `ignoregamma`

### DIFF
--- a/load_llff.py
+++ b/load_llff.py
@@ -107,7 +107,7 @@ def _load_data(basedir, factor=None, width=None, height=None, load_imgs=True):
     
     def imread(f):
         if f.endswith('png'):
-            return imageio.imread(f, ignoregamma=True)
+            return imageio.imread(f, apply_gamma=True)
         else:
             return imageio.imread(f)
         


### PR DESCRIPTION
Refactor `imread` function call to use `apply_gamma=False` for compatibility with latest `imageio`.

In `load_llff.py`, updated the `imread` function call to use `apply_gamma=False` instead of the deprecated `ignoregamma=True` argument. This change ensures compatibility with the latest version of `imageio`, addressing issues reported in https://github.com/yenchenlin/nerf-pytorch/issues/140.

A similar issue and corresponding pull request have been raised for the original TensorFlow version of NeRF (bmild/nerf) here: [Issue #190](https://github.com/bmild/nerf/issues/190) and [Pull Request #210](https://github.com/bmild/nerf/pull/210).