### PR TITLE
Make it work on MAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a fork created by Tail-19, aiming to make this repository work on M1 chip. The project has finished 🎉
+
 # NeRF-pytorch
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.11.0
+# torch==1.11.0
 torchvision>=0.9.1
 imageio
 imageio-ffmpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# torch==1.11.0
+torch>=1.11.0
 torchvision>=0.9.1
 imageio
 imageio-ffmpeg

--- a/run_nerf.py
+++ b/run_nerf.py
@@ -24,8 +24,6 @@ mps_device = torch.device("mps")
 np.random.seed(0)
 DEBUG = False
 
-.to(device)
-
 
 def batchify(fn, chunk):
     """Constructs a version of 'fn' that applies to smaller batches.
@@ -191,14 +189,14 @@ def create_nerf(args):
     skips = [4]
     model = NeRF(D=args.netdepth, W=args.netwidth,
                  input_ch=input_ch, output_ch=output_ch, skips=skips,
-                 input_ch_views=input_ch_views, use_viewdirs=args.use_viewdirs).to(device)
+                 input_ch_views=input_ch_views, use_viewdirs=args.use_viewdirs).to(mps_device)
     grad_vars = list(model.parameters())
 
     model_fine = None
     if args.N_importance > 0:
         model_fine = NeRF(D=args.netdepth_fine, W=args.netwidth_fine,
                           input_ch=input_ch, output_ch=output_ch, skips=skips,
-                          input_ch_views=input_ch_views, use_viewdirs=args.use_viewdirs).to(device)
+                          input_ch_views=input_ch_views, use_viewdirs=args.use_viewdirs).to(mps_device)
         grad_vars += list(model_fine.parameters())
 
     network_query_fn = lambda inputs, viewdirs, network_fn : run_network(inputs, viewdirs, network_fn,
@@ -653,7 +651,7 @@ def train():
     render_kwargs_test.update(bds_dict)
 
     # Move testing data to GPU
-    render_poses = torch.Tensor(render_poses).to(device)
+    render_poses = torch.Tensor(render_poses).to(mps_device)
 
     # Short circuit if only rendering out from trained model
     if args.render_only:
@@ -697,10 +695,10 @@ def train():
 
     # Move training data to GPU
     if use_batching:
-        images = torch.Tensor(images).to(device)
-    poses = torch.Tensor(poses).to(device)
+        images = torch.Tensor(images).to(mps_device)
+    poses = torch.Tensor(poses).to(mps_device)
     if use_batching:
-        rays_rgb = torch.Tensor(rays_rgb).to(device)
+        rays_rgb = torch.Tensor(rays_rgb).to(mps_device)
 
 
     N_iters = 200000 + 1
@@ -734,7 +732,7 @@ def train():
             # Random from one image
             img_i = np.random.choice(i_train)
             target = images[img_i]
-            target = torch.Tensor(target).to(device)
+            target = torch.Tensor(target).to(mps_device)
             pose = poses[img_i, :3,:4]
 
             if N_rand is not None:
@@ -826,7 +824,7 @@ def train():
             os.makedirs(testsavedir, exist_ok=True)
             print('test poses shape', poses[i_test].shape)
             with torch.no_grad():
-                render_path(torch.Tensor(poses[i_test]).to(device), hwf, K, args.chunk, render_kwargs_test, gt_imgs=images[i_test], savedir=testsavedir)
+                render_path(torch.Tensor(poses[i_test]).to(mps_device), hwf, K, args.chunk, render_kwargs_test, gt_imgs=images[i_test], savedir=testsavedir)
             print('Saved test set')
 
 

--- a/run_nerf.py
+++ b/run_nerf.py
@@ -19,9 +19,12 @@ from load_blender import load_blender_data
 from load_LINEMOD import load_LINEMOD_data
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+# device = torch.device("mps" if torch.mps.is_available() else "cpu")
+mps_device = torch.device("mps")
 np.random.seed(0)
 DEBUG = False
+
+.to(device)
 
 
 def batchify(fn, chunk):
@@ -152,8 +155,8 @@ def render_path(render_poses, hwf, K, chunk, render_kwargs, gt_imgs=None, savedi
         print(i, time.time() - t)
         t = time.time()
         rgb, disp, acc, _ = render(H, W, K, chunk=chunk, c2w=c2w[:3,:4], **render_kwargs)
-        rgbs.append(rgb.cpu().numpy())
-        disps.append(disp.cpu().numpy())
+        rgbs.append(rgb.mps().numpy())
+        disps.append(disp.mps().numpy())
         if i==0:
             print(rgb.shape, disp.shape)
 
@@ -275,7 +278,9 @@ def raw2outputs(raw, z_vals, rays_d, raw_noise_std=0, white_bkgd=False, pytest=F
     raw2alpha = lambda raw, dists, act_fn=F.relu: 1.-torch.exp(-act_fn(raw)*dists)
 
     dists = z_vals[...,1:] - z_vals[...,:-1]
-    dists = torch.cat([dists, torch.Tensor([1e10]).expand(dists[...,:1].shape)], -1)  # [N_rays, N_samples]
+    # print(type(dists))
+    # print(dists.device)
+    dists = torch.cat([dists, torch.Tensor([1e10]).expand(dists[...,:1].shape).to("mps")], -1)  # [N_rays, N_samples]
 
     dists = dists * torch.norm(rays_d[...,None,:], dim=-1)
 
@@ -765,7 +770,8 @@ def train():
         img_loss = img2mse(rgb, target_s)
         trans = extras['raw'][...,-1]
         loss = img_loss
-        psnr = mse2psnr(img_loss)
+        with torch.device(device):
+            psnr = mse2psnr(img_loss)   
 
         if 'rgb0' in extras:
             img_loss0 = img2mse(extras['rgb0'], target_s)
@@ -873,6 +879,9 @@ def train():
 
 
 if __name__=='__main__':
-    torch.set_default_tensor_type('torch.cuda.FloatTensor')
-
+    # torch.set_default_tensor_type('torch.mps.FloatTensor')
+    torch.set_default_tensor_type('torch.FloatTensor')
+    
+    torch.set_default_dtype(torch.float32)
+    torch.set_default_device(torch.device("mps"))
     train()

--- a/run_nerf.py
+++ b/run_nerf.py
@@ -768,8 +768,7 @@ def train():
         img_loss = img2mse(rgb, target_s)
         trans = extras['raw'][...,-1]
         loss = img_loss
-        with torch.device(device):
-            psnr = mse2psnr(img_loss)   
+        psnr = mse2psnr(img_loss)   
 
         if 'rgb0' in extras:
             img_loss0 = img2mse(extras['rgb0'], target_s)

--- a/run_nerf.py
+++ b/run_nerf.py
@@ -153,8 +153,8 @@ def render_path(render_poses, hwf, K, chunk, render_kwargs, gt_imgs=None, savedi
         print(i, time.time() - t)
         t = time.time()
         rgb, disp, acc, _ = render(H, W, K, chunk=chunk, c2w=c2w[:3,:4], **render_kwargs)
-        rgbs.append(rgb.mps().numpy())
-        disps.append(disp.mps().numpy())
+        rgbs.append(rgb.cpu().numpy())
+        disps.append(disp.cpu().numpy())
         if i==0:
             print(rgb.shape, disp.shape)
 

--- a/run_nerf.py
+++ b/run_nerf.py
@@ -19,8 +19,7 @@ from load_blender import load_blender_data
 from load_LINEMOD import load_LINEMOD_data
 
 
-# device = torch.device("mps" if torch.mps.is_available() else "cpu")
-mps_device = torch.device("mps")
+device = torch.device("cuda" if torch.cuda.is_available() else "mps" if torch.mps.device_count() > 0 else "cpu")
 np.random.seed(0)
 DEBUG = False
 
@@ -189,14 +188,14 @@ def create_nerf(args):
     skips = [4]
     model = NeRF(D=args.netdepth, W=args.netwidth,
                  input_ch=input_ch, output_ch=output_ch, skips=skips,
-                 input_ch_views=input_ch_views, use_viewdirs=args.use_viewdirs).to(mps_device)
+                 input_ch_views=input_ch_views, use_viewdirs=args.use_viewdirs).to(device)
     grad_vars = list(model.parameters())
 
     model_fine = None
     if args.N_importance > 0:
         model_fine = NeRF(D=args.netdepth_fine, W=args.netwidth_fine,
                           input_ch=input_ch, output_ch=output_ch, skips=skips,
-                          input_ch_views=input_ch_views, use_viewdirs=args.use_viewdirs).to(mps_device)
+                          input_ch_views=input_ch_views, use_viewdirs=args.use_viewdirs).to(device)
         grad_vars += list(model_fine.parameters())
 
     network_query_fn = lambda inputs, viewdirs, network_fn : run_network(inputs, viewdirs, network_fn,
@@ -651,7 +650,7 @@ def train():
     render_kwargs_test.update(bds_dict)
 
     # Move testing data to GPU
-    render_poses = torch.Tensor(render_poses).to(mps_device)
+    render_poses = torch.Tensor(render_poses).to(device)
 
     # Short circuit if only rendering out from trained model
     if args.render_only:
@@ -695,10 +694,10 @@ def train():
 
     # Move training data to GPU
     if use_batching:
-        images = torch.Tensor(images).to(mps_device)
-    poses = torch.Tensor(poses).to(mps_device)
+        images = torch.Tensor(images).to(device)
+    poses = torch.Tensor(poses).to(device)
     if use_batching:
-        rays_rgb = torch.Tensor(rays_rgb).to(mps_device)
+        rays_rgb = torch.Tensor(rays_rgb).to(device)
 
 
     N_iters = 200000 + 1
@@ -732,7 +731,7 @@ def train():
             # Random from one image
             img_i = np.random.choice(i_train)
             target = images[img_i]
-            target = torch.Tensor(target).to(mps_device)
+            target = torch.Tensor(target).to(device)
             pose = poses[img_i, :3,:4]
 
             if N_rand is not None:
@@ -823,7 +822,7 @@ def train():
             os.makedirs(testsavedir, exist_ok=True)
             print('test poses shape', poses[i_test].shape)
             with torch.no_grad():
-                render_path(torch.Tensor(poses[i_test]).to(mps_device), hwf, K, args.chunk, render_kwargs_test, gt_imgs=images[i_test], savedir=testsavedir)
+                render_path(torch.Tensor(poses[i_test]).to(device), hwf, K, args.chunk, render_kwargs_test, gt_imgs=images[i_test], savedir=testsavedir)
             print('Saved test set')
 
 

--- a/run_nerf_helpers.py
+++ b/run_nerf_helpers.py
@@ -7,7 +7,7 @@ import numpy as np
 
 # Misc
 img2mse = lambda x, y : torch.mean((x - y) ** 2)
-mse2psnr = lambda x : -10. * torch.log(x) / torch.log(torch.Tensor([10.]))
+mse2psnr = lambda x : -10. * torch.log(x) / torch.log(torch.Tensor([10.]).to(x.device))
 to8b = lambda x : (255*np.clip(x,0,1)).astype(np.uint8)
 
 


### PR DESCRIPTION
PyTorch added support for M1 GPU as of 2022-05-18 in the Nightly version, this version made some small modifications to make it also work on Mac without any changes to the original workflow. The code is tested on the Apple M1 Max chip with torch                   2.4.1
torchvision             0.19.1